### PR TITLE
[TTDP-5946] fix: Suppress excessive prometheus logging for non-premium user

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3109,7 +3109,7 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
         elif logging_integration == "prometheus":
             if "LITELLM_LICENSE" not in os.environ:
                 verbose_logger.debug(
-                    f"Prometheus Logger supressed due to no LITELLM_LICENSE"
+                    f"Prometheus Logger suppressed due to no LITELLM_LICENSE"
                 )
                 return None
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3107,6 +3107,12 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
             _in_memory_loggers.append(_literalai_logger)
             return _literalai_logger  # type: ignore
         elif logging_integration == "prometheus":
+            if "LITELLM_LICENSE" not in os.environ:
+                verbose_logger.debug(
+                    f"Prometheus Logger supressed due to no LITELLM_LICENSE"
+                )
+                return None
+
             for callback in _in_memory_loggers:
                 if isinstance(callback, PrometheusLogger):
                     return callback  # type: ignore


### PR DESCRIPTION
## Title

[TTDP-5946] fix: Suppress excessive prometheus logging for non-premium user

## Relevant issues

Fixes problem of PrometheusLogger being used when there is no premium license.

Which resulted in excessive log messages:
```
09:45:23 - LiteLLM:ERROR: prometheus.py:815 - prometheus Layer Error(): Exception occured - 'PrometheusLogger' object has no attribute 'litellm_proxy_total_requests_metric'
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/litellm/integrations/prometheus.py", line 812, in async_post_call_success_hook
    self.litellm_proxy_total_requests_metric.labels(**_labels).inc()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'PrometheusLogger' object has no attribute 'litellm_proxy_total_requests_metric'
```

## Pre-Submission checklist

- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Do not use PrometheusLogger when there is no premium license.
