### PR TITLE
[TTDP-6531] fix(_logging.py): Fix env variables definitions and _is_debugging_on()

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -11,10 +11,10 @@ if set_verbose is True:
     logging.warning(
         "`litellm.set_verbose` is deprecated. Please set `os.environ['LITELLM_LOG'] = 'DEBUG'` for debug logs."
     )
-json_logs = bool(os.getenv("JSON_LOGS", False))
+json_logs = os.getenv("JSON_LOGS", "").lower() in ("true", "1", "yes", "enabled")
 # Create a handler for the logger (you may need to adapt this based on your needs)
 log_level = os.getenv("LITELLM_LOG", "DEBUG")
-numeric_level: str = getattr(logging, log_level.upper())
+numeric_level: int = getattr(logging, log_level.upper())
 handler = logging.StreamHandler()
 handler.setLevel(numeric_level)
 
@@ -172,6 +172,4 @@ def _is_debugging_on() -> bool:
     """
     Returns True if debugging is on
     """
-    if verbose_logger.isEnabledFor(logging.DEBUG) or set_verbose is True:
-        return True
-    return False
+    return any(handler.level <= logging.DEBUG for handler in verbose_logger.handlers) or set_verbose is True


### PR DESCRIPTION
## Title

Logging utilities were incorrectly defined, leading to incorrect behavior of:
* `JSON_LOGS`- incorrect conversion to boolean
* `LITELLM_LOG` - using incorrect numeric level
* `_is_debugging_on()` returned incorrect value

## Pre-Submission checklist

- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

* `JSON_LOGS` is now evaluated based on string values ("true", "1", "yes", "enabled")
* `LITELLM_LOG` uses `int`
* `is_debugging_on()` will check if any of logger handlers has the debug level
