### PR TITLE
Ttdp 7201 Add latencyMs to response body in order to track performance.

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -992,6 +992,12 @@ class AmazonConverseConfig(BaseConfig):
                 message=returned_message,
             )
         ]
+
+        # update model with server side latency
+        latency = completion_response.get("metrics", {}).get("latencyMs", 0)
+        if latency > 0:
+            model_response._hidden_params["latencyMs"] = latency
+
         model_response.created = int(time.time())
         model_response.model = model
 

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -226,6 +226,9 @@ class ProxyBaseLLMRequestProcessing:
             ),
             "x-litellm-timeout": str(timeout) if timeout is not None else None,
             **{k: str(v) for k, v in kwargs.items()},
+            # upper case are converted to lower case somewhere else
+            # use "-" to separate "ms" instead of original "Ms"
+            "latency-ms": hidden_params.get("latencyMs", None)
         }
         if request_data:
             remaining_tokens_header = (


### PR DESCRIPTION
The purpose of this change is to provide easy access to server side metrics "latencyMs" this metrics is useful to estimate performance of our systems. If latencyMs is not essentially bigger that server side latency this means our system works as expected and in case of increase our own latency. 
The possible options were:
*  put latency in "id" field
* use "system_fingerprint" field (llitellm hard coded null for this field)
* use "created" field (litellm sets it to int(time.time()) - not very useful value to see the time when litellm received response and this is the moment when transformation happens. 
* The latest option was to extends "choices" normally we receie only one choice (litellm hardcoded this - only one choice).

The latest option was implemented: Proxy extends and creates additional choice entry with "latencyMs:<int>" in {"messages":{"content":"latencyMs:<int>"}}. 

The llm helper needs an update to extract this value from the response (already implemented)  and probably remove this second choice at all  (easy to do ) in order to have answer without any custom updates. I will created llm-helper PR after this PR.

The sample of original message (json is in use, yaml was used to reduce visual noise in sample):
```
id: chatcmpl-23ef68b8-3fe5-4821-8801-dc71a700d5b3
created: 1753768082
model: anthropic.claude-3-haiku-20240307-v1:0
object: chat.completion
system_fingerprint: null
choices:
  - finish_reason: stop
    index: 0
    message:
      content: ...
      role: assistant
      tool_calls: null
      function_call: null
usage:
  completion_tokens: 49
  prompt_tokens: 28
  total_tokens: 77
  completion_tokens_details: null
  prompt_tokens_details:
    audio_tokens: null
    cached_tokens: 0
  cache_creation_input_tokens: 0
  cache_read_input_tokens: 0
```
The sample with added choice entry:
```
id: chatcmpl-23ef68b8-3fe5-4821-8801-dc71a700d5b3
created: 1753768082
model: anthropic.claude-3-haiku-20240307-v1:0
object: chat.completion
system_fingerprint: null
choices:
  - finish_reason: stop
    index: 0
    message:
      content: ...
      role: assistant
      tool_calls: null
      function_call: null
  - finish_reason: stop
    index: 1
    message:
      content: {LatencyMs:1234}
      role: assistant
      tool_calls: null
      function_call: null
usage:
  completion_tokens: 49
  prompt_tokens: 28
  total_tokens: 77
  completion_tokens_details: null
  prompt_tokens_details:
    audio_tokens: null
    cached_tokens: 0
  cache_creation_input_tokens: 0
  cache_read_input_tokens: 0
```

